### PR TITLE
Ignore file size warning for the demo

### DIFF
--- a/feltboard-2022/webpack.config.js
+++ b/feltboard-2022/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = {
         },
     },
     performance: {
-        hints: "warning", // enum
+        hints: false, // enum
         maxAssetSize: 6000000, // int (in bytes),
         maxEntrypointSize: 6000000, // int (in bytes)
         assetFilter: function(assetFilename) {


### PR DESCRIPTION
Quick change to ignore the warning on running the demo app